### PR TITLE
Initial implementation of api /process/upload that accepts any file a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# file-service-poc
-An example spring boot application to handle file uploads and processing
+# File Service (POC)
+
+An example spring boot application to handle file uploads and processing.
+
+The project has the intention of receive a file via rest api and returning a processed file back to the api consumer.
+
+---
+
+### Running the project
+
+To run the project locally, ensure to install the project to it can generate a JAR file
+
+```bash
+make install
+```
+
+THe command above will install the project via docker and generate a JAR file at the root file of this project
+
+```bash
+make run
+```
+
+The project will run via docker in a secured java environment and will be available on port 9090
+
+---
+
+### Testing the project running via health endpoint
+
+```bash
+curl --location 'http://localhost:9090/app/actuator/health'
+```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>uk.co.mulecode</groupId>
-    <artifactId>file-service</artifactId>
+    <artifactId>file-service-poc</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>file-service-poc</name>
     <description>Example service for file processing</description>

--- a/src/main/java/uk/co/mulecode/fileservice/component/properties/AppProperty.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/properties/AppProperty.java
@@ -1,10 +1,12 @@
 package uk.co.mulecode.fileservice.component.properties;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Data
+@Getter
+@Setter
 @Component
 @ConfigurationProperties(prefix = "application")
 public class AppProperty {

--- a/src/main/java/uk/co/mulecode/fileservice/controller/ControllerUtils.java
+++ b/src/main/java/uk/co/mulecode/fileservice/controller/ControllerUtils.java
@@ -1,0 +1,25 @@
+package uk.co.mulecode.fileservice.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+/**
+ * Utility class for controller
+ */
+public class ControllerUtils {
+
+    /**
+     * Build headers for file response in the api
+     *
+     * @param responseBytes file bytes
+     * @param filename      file name
+     * @return HttpHeaders for api response
+     */
+    public HttpHeaders buildHeadersFileResponse(byte[] responseBytes, String filename) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        headers.setContentLength(responseBytes.length);
+        headers.setContentDispositionFormData("attachment", filename);
+        return headers;
+    }
+}

--- a/src/main/java/uk/co/mulecode/fileservice/controller/FileProcessorController.java
+++ b/src/main/java/uk/co/mulecode/fileservice/controller/FileProcessorController.java
@@ -1,0 +1,30 @@
+package uk.co.mulecode.fileservice.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@RestController
+@RequestMapping("/process")
+@RequiredArgsConstructor
+public class FileProcessorController extends ControllerUtils {
+
+    private final static String RESPONSE_FILE_NAME = "OutcomeFile.json";
+
+    @PostMapping(value = "/upload", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> processFile(MultipartFile file) throws Exception {
+        log.info("Processing file: {}", file.getOriginalFilename());
+
+        final byte[] responseBytes = file.getBytes();
+
+        return ResponseEntity.ok().headers(buildHeadersFileResponse(responseBytes, RESPONSE_FILE_NAME)).body(responseBytes);
+    }
+
+}

--- a/src/test/java/uk/co/mulecode/fileservice/component/properties/AppPropertyTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/component/properties/AppPropertyTest.java
@@ -1,0 +1,19 @@
+package uk.co.mulecode.fileservice.component.properties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AppPropertyTest extends IntegrationTestBase {
+
+    @Autowired
+    private AppProperty appProperty;
+
+    @Test
+    void getName() {
+        final String name = appProperty.getName();
+        assertEquals("file-service-poc-test", name);
+    }
+}

--- a/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
@@ -1,0 +1,27 @@
+package uk.co.mulecode.fileservice.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FileProcessorControllerTest extends IntegrationTestBase {
+
+    @Test
+    void processFile_ValidFile_ReturnOk() throws Exception {
+
+        String fileName = "data/entry_valid.txt";
+
+        MockMultipartFile file = readFileAsMockMultipartFile(fileName);
+
+        getMvc().perform(multipart("/process/upload").file(file))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-type", "application/octet-stream"))
+                .andExpect(header().string("Content-Disposition", "form-data; name=\"attachment\"; filename=\"OutcomeFile.json\""))
+                .andExpect(content().string(new String(file.getBytes())));
+    }
+}

--- a/src/test/java/uk/co/mulecode/fileservice/utils/UnitTestUtils.java
+++ b/src/test/java/uk/co/mulecode/fileservice/utils/UnitTestUtils.java
@@ -6,7 +6,6 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.jeasy.random.EasyRandom;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -21,7 +20,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Getter
 public class UnitTestUtils {
 

--- a/src/test/java/uk/co/mulecode/fileservice/utils/UnitTestUtils.java
+++ b/src/test/java/uk/co/mulecode/fileservice/utils/UnitTestUtils.java
@@ -6,6 +6,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.jeasy.random.EasyRandom;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -20,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Getter
 public class UnitTestUtils {
 

--- a/src/test/resources/data/entry_valid.txt
+++ b/src/test/resources/data/entry_valid.txt
@@ -1,0 +1,3 @@
+18148426-89e1-11ee-b9d1-0242ac120002|1X1D14|John Smith|Likes Apricots|Rides A Bike|6.2|12.1
+3ce2d17b-e66a-4c1e-bca3-40eb1c9222c7|2X2D24|Mike Smith|Likes Grape|Drives an SUV|35.0|95.5
+1afb6f5d-a7c2-4311-a92d-974f3180ff5e|3X3D35|Jenny Walters|Likes Avocados|Rides A Scooter|8.5|15.3


### PR DESCRIPTION
Initial implementation of api /process/upload that accepts any file and returns its content to the consumer.

Added:
- Adding test for AppPropertyTest as Coverage was not happy
- Readme file with instructions how to run the project

Fixed:
- application name to file-service to file-service-poc
- AppProperty Removed @Data as it implements equals and hash, sonar wanted it to be tested. replaced to getter and setter, as for this component no need for equals and hash implementations