### PR TITLE
Adding validation to the CSV file in the controller, before it is pro…

### DIFF
--- a/data/schema/ErrorV1Response.json
+++ b/data/schema/ErrorV1Response.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    },
+    "error": {
+      "type": "string"
+    },
+    "errors": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "status": {
+      "type": "integer"
+    },
+    "exception": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "integer"
+    },
+    "path": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "message",
+    "error",
+    "status",
+    "exception",
+    "timestamp",
+    "path"
+  ]
+}

--- a/src/main/java/uk/co/mulecode/fileservice/component/properties/AppProperty.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/properties/AppProperty.java
@@ -12,5 +12,11 @@ import org.springframework.stereotype.Component;
 public class AppProperty {
 
     private String name;
+    private FeaturesFlags featuresFlags;
 
+    @Getter
+    @Setter
+    public static class FeaturesFlags {
+        private boolean enableCsvFileValidation;
+    }
 }

--- a/src/main/java/uk/co/mulecode/fileservice/component/validators/MultipartFileValidator.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/validators/MultipartFileValidator.java
@@ -1,0 +1,81 @@
+package uk.co.mulecode.fileservice.component.validators;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import uk.co.mulecode.fileservice.component.properties.AppProperty;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class MultipartFileValidator implements ConstraintValidator<ValidIngestionFile, MultipartFile> {
+
+    @Setter
+    private Pattern csvLinePatternRegex;
+
+    @Autowired
+    private AppProperty appProperty;
+
+    @Override
+    public void initialize(ValidIngestionFile constraintAnnotation) {
+        csvLinePatternRegex = Pattern.compile(constraintAnnotation.pattern());
+    }
+
+    @Override
+    public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+        if (!appProperty.getFeaturesFlags().isEnableCsvFileValidation()) {
+            log.warn("CSV file validation is disabled");
+            return true;
+        }
+        if (value.isEmpty()) {
+            addConstraintViolation(context, "File cannot be empty for ingestion");
+            return false;
+        }
+        if (!isValidCsv(value)) {
+            addConstraintViolation(context, "Invalid CSV file format");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+    }
+
+    private boolean isValidCsv(MultipartFile file) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()))) {
+            List<String> lines = reader.lines().toList();
+            // Check if there is at least one line in the CSV file
+            if (lines.isEmpty()) {
+                return false;
+            }
+            // Check if each line contains a valid CSV format
+            for (String line : lines) {
+                if (!isValidCsvLine(line)) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (IOException e) {
+            log.error("Error reading CSV file", e);
+            return false;
+        }
+    }
+
+    private boolean isValidCsvLine(String line) {
+        Matcher matcher = csvLinePatternRegex.matcher(line);
+        return matcher.matches();
+    }
+}

--- a/src/main/java/uk/co/mulecode/fileservice/component/validators/ValidIngestionFile.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/validators/ValidIngestionFile.java
@@ -1,0 +1,25 @@
+package uk.co.mulecode.fileservice.component.validators;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = {MultipartFileValidator.class})
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidIngestionFile {
+
+    String pattern() default ".*";
+
+    String message() default "{jakarta.validation.constraints.ValidIngestionFile.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/co/mulecode/fileservice/component/validators/patterns/RegexPatterns.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/validators/patterns/RegexPatterns.java
@@ -1,0 +1,12 @@
+package uk.co.mulecode.fileservice.component.validators.patterns;
+
+public final class RegexPatterns {
+
+    public static final String CSV_LINE_PATTERN = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\|" +  // UUID
+            "\\w+\\|" +  // Code (assuming it consists of word characters only)
+            ".+?\\|" +   // Name (assuming it can contain any characters)
+            ".+?\\|" +   // likes (assuming it can contain any characters)
+            ".+?\\|" +   // transport (assuming it can contain any characters)
+            "\\d+\\.?\\d*\\|" +  // avgSpeed (assuming it's a decimal number)
+            "\\d+\\.?\\d*$";     // topSpeed (assuming it's a decimal number)
+}

--- a/src/main/java/uk/co/mulecode/fileservice/controller/FileProcessorController.java
+++ b/src/main/java/uk/co/mulecode/fileservice/controller/FileProcessorController.java
@@ -1,19 +1,24 @@
 package uk.co.mulecode.fileservice.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import uk.co.mulecode.fileservice.component.validators.ValidIngestionFile;
 import uk.co.mulecode.fileservice.service.FileIngestionService;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.co.mulecode.fileservice.component.validators.patterns.RegexPatterns.CSV_LINE_PATTERN;
 
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/process")
 @RequiredArgsConstructor
@@ -24,7 +29,7 @@ public class FileProcessorController extends ControllerUtils {
     private final FileIngestionService fileIngestionService;
 
     @PostMapping(value = "/upload", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> processFile(MultipartFile file) {
+    public ResponseEntity<?> processFile(@Valid @ValidIngestionFile(pattern = CSV_LINE_PATTERN) MultipartFile file) {
         log.info("Processing file: {}", file.getOriginalFilename());
 
         String processedFileResponse = fileIngestionService.processFile(file);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,5 @@ spring:
 
 application:
   name: file-service-poc
+  features-flags:
+    enable-csv-file-validation: true

--- a/src/test/java/uk/co/mulecode/fileservice/component/validators/MultipartFileValidatorTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/component/validators/MultipartFileValidatorTest.java
@@ -1,0 +1,80 @@
+package uk.co.mulecode.fileservice.component.validators;
+
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Builder;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import uk.co.mulecode.fileservice.component.validators.patterns.RegexPatterns;
+import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MultipartFileValidatorTest extends IntegrationTestBase {
+
+    @Autowired
+    private MultipartFileValidator multipartFileValidator;
+
+    @BeforeEach
+    void setUp() {
+        // Inject the regex pattern for the CSV line
+        multipartFileValidator.setCsvLinePatternRegex(
+                Pattern.compile(RegexPatterns.CSV_LINE_PATTERN)
+        );
+    }
+
+    private static Stream<TestIsValidOptions> isValidOptions() {
+        return Stream.of(
+                TestIsValidOptions.builder().filename("data/entry_valid.txt")
+                        .expected(true)
+                        .build(),
+                TestIsValidOptions.builder().filename("data/entry_invalid_empty.txt")
+                        .expected(false)
+                        .errorMessage("File cannot be empty for ingestion")
+                        .build(),
+                TestIsValidOptions.builder().filename("data/entry_invalid.txt")
+                        .expected(false)
+                        .errorMessage("Invalid CSV file format")
+                        .build()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("isValidOptions")
+    void isValid(TestIsValidOptions validOdds) throws Exception {
+        ConstraintValidatorContext constraintValidatorContext = mock(ConstraintValidatorContext.class);
+        ConstraintValidatorContext.ConstraintViolationBuilder builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        when(constraintValidatorContext.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+        String fileName = validOdds.getFilename();
+
+        MockMultipartFile file = readFileAsMockMultipartFile(fileName);
+
+        boolean valid = multipartFileValidator.isValid(file, constraintValidatorContext);
+
+        assertEquals(valid, validOdds.isExpected());
+
+        if (!validOdds.isExpected()) {
+            verify(builder).addConstraintViolation();
+            verify(constraintValidatorContext).buildConstraintViolationWithTemplate(validOdds.getErrorMessage());
+        }
+    }
+
+    @Data
+    @Builder
+    private static class TestIsValidOptions {
+        String filename;
+        boolean expected;
+        String errorMessage;
+        boolean disableCsvFileValidation;
+    }
+}

--- a/src/test/java/uk/co/mulecode/fileservice/component/validators/patterns/RegexPatternsTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/component/validators/patterns/RegexPatternsTest.java
@@ -1,0 +1,54 @@
+package uk.co.mulecode.fileservice.component.validators.patterns;
+
+import lombok.Builder;
+import lombok.Data;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RegexPatternsTest {
+
+
+    private static Stream<TestIsValidOptions> isValidOptions() {
+        return Stream.of(
+                TestIsValidOptions.builder()
+                        .pattern(RegexPatterns.CSV_LINE_PATTERN)
+                        .value("18148426-89e1-11ee-b9d1-0242ac120002|1X1D14|John Smith|Likes Apricots|Rides A Bike|6.2|12.1")
+                        .expected(true)
+                        .build(),
+                TestIsValidOptions.builder()
+                        .pattern(RegexPatterns.CSV_LINE_PATTERN)
+                        .value("")
+                        .expected(false)
+                        .build(),
+                TestIsValidOptions.builder()
+                        .pattern(RegexPatterns.CSV_LINE_PATTERN)
+                        .value("-89e1-11e-b9d1-0242ac120002|||1X1D14|John Smith|Likes Apric Bike|6.2|12.1")
+                        .expected(false)
+                        .build()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("isValidOptions")
+    void testCSVPattern(TestIsValidOptions validOdds) {
+
+        Matcher matcher = Pattern.compile(validOdds.getPattern())
+                .matcher(validOdds.getValue());
+
+        assertEquals(validOdds.isExpected(), matcher.matches());
+    }
+
+    @Data
+    @Builder
+    private static class TestIsValidOptions {
+        String value;
+        String pattern;
+        boolean expected;
+    }
+}

--- a/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
@@ -1,10 +1,16 @@
 package uk.co.mulecode.fileservice.controller;
 
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import uk.co.mulecode.fileservice.component.properties.AppProperty;
 import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,6 +18,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.co.mulecode.fileservice.utils.matchers.JsonSchemaResultMatcher.validateSchema;
 
 class FileProcessorControllerTest extends IntegrationTestBase {
+
+    @MockBean
+    private AppProperty appProperty;
+
+    @BeforeEach
+    void setUp() {
+        //Default behaviour
+        AppProperty.FeaturesFlags FeaturesFlagsMock = mock(AppProperty.FeaturesFlags.class);
+        when(FeaturesFlagsMock.isEnableCsvFileValidation()).thenReturn(true);
+        when(appProperty.getFeaturesFlags()).thenReturn(FeaturesFlagsMock);
+    }
 
     @Test
     void processFile_ValidFile_ReturnOk() throws Exception {
@@ -27,5 +44,49 @@ class FileProcessorControllerTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$", hasSize(3)))
                 .andExpect(validateSchema("./data/schema/OutcomeV1Response.json"));
+    }
+
+    @Test
+    void processFile_InvalidEmpty_ReturnBadRequest() throws Exception {
+
+        String fileName = "data/entry_invalid_empty.txt";
+
+        MockMultipartFile file = readFileAsMockMultipartFile(fileName);
+
+        getMvc().perform(multipart("/process/upload").file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(header().string("Content-type", "application/json"))
+                .andExpect(jsonPath("$").isMap())
+                .andExpect(jsonPath("$.message").value("Validation failed, error count: 1"))
+                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.exception").value("jakarta.validation.ConstraintViolationException"))
+                .andExpect(jsonPath("$.path").value("/process/upload"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(validateSchema("./data/schema/ErrorV1Response.json"));
+    }
+
+    @Test
+    void processFile_InvalidCSVDisabledValidation_ReturnInternalServerError() throws Exception {
+        // Disable CSV file validation
+        AppProperty.FeaturesFlags FeaturesFlagsMock = mock(AppProperty.FeaturesFlags.class);
+        when(FeaturesFlagsMock.isEnableCsvFileValidation()).thenReturn(false);
+        when(appProperty.getFeaturesFlags()).thenReturn(FeaturesFlagsMock);
+
+        String fileName = "data/entry_invalid.txt";
+
+        MockMultipartFile file = readFileAsMockMultipartFile(fileName);
+
+        getMvc().perform(multipart("/process/upload").file(file))
+                .andExpect(status().isInternalServerError())
+                .andExpect(header().string("Content-type", "application/json"))
+                .andExpect(jsonPath("$").isMap())
+                .andExpect(jsonPath("$.message", Matchers.startsWith("Unhandled error exception - Error parsing CSV line")))
+                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.exception").value("java.lang.RuntimeException"))
+                .andExpect(jsonPath("$.path").value("/process/upload"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(validateSchema("./data/schema/ErrorV1Response.json"));
     }
 }

--- a/src/test/resources/data/entry_invalid.txt
+++ b/src/test/resources/data/entry_invalid.txt
@@ -1,0 +1,3 @@
+-89e1-11e-b9d1-0242ac120002|||1X1D14|John Smith|Likes Apric Bike|6.2|12.1
+3ce2d17b-e66a-4c1e-bca3-40eb1c9222c7Mike Smith|Likes Grape|Drives an SUV|35.0|95.5
+1afb6f5d-a711-a92d-974f3180ff5e|3X3D35|Jenny Walters|Likes Scooter|8.5|15.3


### PR DESCRIPTION
Adding validation to the CSV file in the controller, before it is processed - it validates when the file is empty and regex to ensure each line is in the expected format

added 
- validation for CVS file with a custom annotation processor
- Error response schema
- Feature flag to disable validations (can be problematic as the validation is the only way to ensure correct parsing)
- files samples for testing negative scenarios