### PR TITLE
Add IP policy rule in interceptor to check ip data from ip-api reposi…

### DIFF
--- a/src/main/java/uk/co/mulecode/fileservice/component/interceptors/RequestIPVerifierInterceptor.java
+++ b/src/main/java/uk/co/mulecode/fileservice/component/interceptors/RequestIPVerifierInterceptor.java
@@ -7,11 +7,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
+import uk.co.mulecode.fileservice.repository.IPDataRepository;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
+
+import java.util.function.Predicate;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RequestIPVerifierInterceptor implements HandlerInterceptor {
+
+    private final IPDataRepository ipDataRepository;
+    private final Predicate<IPDataResponse> ipBlockingPolicy;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -19,6 +26,11 @@ public class RequestIPVerifierInterceptor implements HandlerInterceptor {
         long requestStartTime = System.currentTimeMillis();
         String ipAddress = request.getRemoteAddr();
         log.debug(">>>> preHandle - ipAddress: {} at {}", ipAddress, requestStartTime);
+        IPDataResponse iPdata = ipDataRepository.getIPdata(ipAddress);
+        if (ipBlockingPolicy.test(iPdata)) {
+            log.debug(">>>> preHandle - ipAddress blocked: {} Income connection policy rule activated for ip data {}", ipAddress, iPdata);
+        }
+
         return true;
     }
 

--- a/src/main/java/uk/co/mulecode/fileservice/config/IPBlockingPolicyConfig.java
+++ b/src/main/java/uk/co/mulecode/fileservice/config/IPBlockingPolicyConfig.java
@@ -1,0 +1,21 @@
+package uk.co.mulecode.fileservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
+
+import java.util.function.Predicate;
+
+@Configuration
+public class IPBlockingPolicyConfig {
+
+    @Bean
+    public Predicate<IPDataResponse> ipBlockingPolicy() {
+        return ipDataResponse -> ipDataResponse.getCountryCode().equalsIgnoreCase("CN") ||
+                ipDataResponse.getCountryCode().equalsIgnoreCase("ES") ||
+                ipDataResponse.getCountryCode().equalsIgnoreCase("US") ||
+                ipDataResponse.getIsp().equalsIgnoreCase("AWS") ||
+                ipDataResponse.getIsp().equalsIgnoreCase("GCP") ||
+                ipDataResponse.getIsp().equalsIgnoreCase("Azure");
+    }
+}

--- a/src/test/java/uk/co/mulecode/fileservice/component/interceptors/RequestVerifierInterceptorTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/component/interceptors/RequestVerifierInterceptorTest.java
@@ -1,26 +1,42 @@
 package uk.co.mulecode.fileservice.component.interceptors;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import uk.co.mulecode.fileservice.repository.IPDataRepository;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
+import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.co.mulecode.stubs.IPApiStub.TEST_IP;
 
-class RequestVerifierInterceptorTest {
+class RequestVerifierInterceptorTest extends IntegrationTestBase {
 
-    private final RequestIPVerifierInterceptor interceptor = new RequestIPVerifierInterceptor();
+    @Autowired
+    private RequestIPVerifierInterceptor interceptor;
+
+    @MockBean
+    private IPDataRepository ipDataRepository;
 
     @Test
     public void preHandle_GetRemoteAddress() throws Exception {
         // given
+        IPDataResponse ipDataResponse = givenOneObjectOf(IPDataResponse.class);
+        when(ipDataRepository.getIPdata(TEST_IP)).thenReturn(ipDataResponse);
+
         MockHttpServletRequest request = mock(MockHttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn(TEST_IP);
         MockHttpServletResponse response = new MockHttpServletResponse();
         Object handler = new Object();
         // when
         interceptor.preHandle(request, response, handler);
         // then
-        Mockito.verify(request, times(1)).getRemoteAddr();
+        verify(request, times(1)).getRemoteAddr();
+        verify(ipDataRepository, times(1)).getIPdata(TEST_IP);
     }
 }

--- a/src/test/java/uk/co/mulecode/fileservice/config/IPBlockingPolicyConfigTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/config/IPBlockingPolicyConfigTest.java
@@ -1,0 +1,59 @@
+package uk.co.mulecode.fileservice.config;
+
+import lombok.Builder;
+import lombok.Data;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
+import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IPBlockingPolicyConfigTest extends IntegrationTestBase {
+
+    @Autowired
+    Predicate<IPDataResponse> ipBlockingPolicy;
+
+    private static Stream<TestIsValidOptions> isValidOptions() {
+        return Stream.of(
+                testBuilder("CN", "AT&T", true),
+                testBuilder("ES", "AT&T", true),
+                testBuilder("US", "AT&T", true),
+                testBuilder("UK", "AWS", true),
+                testBuilder("UK", "GCP", true),
+                testBuilder("UK", "Azure", true),
+                testBuilder("BR", "Atlantic Broadband", false),
+                testBuilder("UK", "Google Fiber", false),
+                testBuilder("IT", "AT&T", false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("isValidOptions")
+    void ipBlockingPolicy(TestIsValidOptions validOdds) {
+        final boolean isIpBlocked = ipBlockingPolicy.test(validOdds.getValue());
+        assertEquals(validOdds.isExpected(), isIpBlocked);
+    }
+
+    @Data
+    @Builder
+    private static class TestIsValidOptions {
+        IPDataResponse value;
+        boolean expected;
+    }
+
+    private static TestIsValidOptions testBuilder(String countryCode, String ips, boolean expected) {
+        return TestIsValidOptions.builder()
+                .value(IPDataResponse.builder()
+                        .isp(ips)
+                        .countryCode(countryCode)
+                        .build())
+                .expected(expected)
+                .build();
+    }
+
+}

--- a/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerTest.java
@@ -1,8 +1,12 @@
 package uk.co.mulecode.fileservice.controller;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
+import uk.co.mulecode.fileservice.component.mappers.JsonMapper;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
 import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+import uk.co.mulecode.stubs.IPApiStub;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -13,8 +17,13 @@ import static uk.co.mulecode.fileservice.utils.matchers.JsonSchemaValidatorResul
 
 class FileProcessorControllerTest extends IntegrationTestBase {
 
+    @Autowired
+    private JsonMapper jsonMapper;
+
     @Test
     void processFile_ValidFile_ReturnOk() throws Exception {
+
+        IPApiStub.stubSuccessApiResponse(jsonMapper.toJson(givenOneObjectOf(IPDataResponse.class)));
 
         String fileName = "data/entry_valid.txt";
 
@@ -31,6 +40,8 @@ class FileProcessorControllerTest extends IntegrationTestBase {
 
     @Test
     void processFile_InvalidEmpty_ReturnBadRequest() throws Exception {
+
+        IPApiStub.stubSuccessApiResponse(jsonMapper.toJson(givenOneObjectOf(IPDataResponse.class)));
 
         String fileName = "data/entry_invalid_empty.txt";
 

--- a/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerValidationDisabledTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/controller/FileProcessorControllerValidationDisabledTest.java
@@ -2,9 +2,13 @@ package uk.co.mulecode.fileservice.controller;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import uk.co.mulecode.fileservice.component.mappers.JsonMapper;
+import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
 import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+import uk.co.mulecode.stubs.IPApiStub;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -15,8 +19,13 @@ import static uk.co.mulecode.fileservice.utils.matchers.JsonSchemaValidatorResul
 @ActiveProfiles("test-csv-validation-disabled")
 class FileProcessorControllerValidationDisabledTest extends IntegrationTestBase {
 
+    @Autowired
+    private JsonMapper jsonMapper;
+
     @Test
     void processFile_InvalidCSVDisabledValidation_ReturnInternalServerError() throws Exception {
+
+        IPApiStub.stubSuccessApiResponse(jsonMapper.toJson(givenOneObjectOf(IPDataResponse.class)));
 
         String fileName = "data/entry_invalid.txt";
 

--- a/src/test/java/uk/co/mulecode/fileservice/repository/IPDataRepositoryTest.java
+++ b/src/test/java/uk/co/mulecode/fileservice/repository/IPDataRepositoryTest.java
@@ -2,28 +2,22 @@ package uk.co.mulecode.fileservice.repository;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.client.HttpServerErrorException;
 import uk.co.mulecode.fileservice.component.mappers.JsonMapper;
 import uk.co.mulecode.fileservice.repository.dto.IPDataResponse;
 import uk.co.mulecode.fileservice.utils.IntegrationTestBase;
+import uk.co.mulecode.stubs.IPApiStub;
 
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.mulecode.fileservice.utils.matchers.impl.JsonSchemaValidatorMatcher.assertSchema;
+import static uk.co.mulecode.stubs.IPApiStub.TEST_IP;
 
-class IPDataRepositoryTest extends IntegrationTestBase {
-
-    public static final String TEST_IP = "24.48.0.1";
+public class IPDataRepositoryTest extends IntegrationTestBase {
 
     @Autowired
     private IPDataRepository ipDataRepository;
@@ -36,27 +30,18 @@ class IPDataRepositoryTest extends IntegrationTestBase {
 
         final IPDataResponse ipDataResponse = givenOneObjectOf(IPDataResponse.class);
 
-        stubFor(get(urlEqualTo("/json/" + TEST_IP + "?fields=66846719"))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                        .withBody(jsonMapper.toJson(ipDataResponse))));
+        IPApiStub.stubSuccessApiResponse(jsonMapper.toJson(ipDataResponse));
 
         final IPDataResponse iPdata = ipDataRepository.getIPdata(TEST_IP);
 
         assertNotNull(iPdata);
         assertSchema(jsonMapper.toJson(iPdata), "./data/schema/IPDataV1Response.json");
-
     }
 
     @Test
     void getIPdata_apiConnectionError_ReturnError() {
 
-        stubFor(get(urlEqualTo("/json/" + TEST_IP + "?fields=66846719"))
-                .willReturn(aResponse()
-                        .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                        .withBody(jsonMapper.toJson(Map.of("error", "Internal server error")))));
+        IPApiStub.stubInternalServerApiResponse(jsonMapper.toJson(Map.of("error", "Internal server error")));
 
         HttpServerErrorException exception = assertThrows(HttpServerErrorException.class, () -> {
             ipDataRepository.getIPdata(TEST_IP);

--- a/src/test/java/uk/co/mulecode/stubs/IPApiStub.java
+++ b/src/test/java/uk/co/mulecode/stubs/IPApiStub.java
@@ -1,0 +1,33 @@
+package uk.co.mulecode.stubs;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+;
+
+public class IPApiStub {
+
+    public static final String TEST_IP = "24.48.0.1";
+
+    public static void stubSuccessApiResponse(String jsonBody) {
+        stubFor(get(urlMatching("/json/(.*)\\?fields=66846719"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+    }
+
+    public static void stubInternalServerApiResponse(String jsonBody) {
+        stubFor(get(urlMatching("/json/(.*)\\?fields=66846719"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+    }
+
+}


### PR DESCRIPTION
Add IP policy rule in interceptor to check ip data from ip-api repository

- moved stubs to a dedicated class
- created IP policy rules
- plugged IP-api in the interceptor so it can trigger for every call
- plugged policy rules in the interceptor so it know when request is blocked (for now when blocked it only logs in debug)